### PR TITLE
kde-misc/kwallet-cli: kdelibs moved to kde-frameworks category

### DIFF
--- a/kde-misc/kwalletcli/kwalletcli-2.11.ebuild
+++ b/kde-misc/kwalletcli/kwalletcli-2.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -17,7 +17,7 @@ KEYWORDS=" ~amd64 ~x86"
 
 RDEPEND="
 	app-shells/mksh
-	kde-base/kdelibs:4
+	kde-frameworks/kdelibs:4
 	kde-apps/kwalletd:4
 "
 DEPEND="${RDEPEND}

--- a/kde-misc/kwalletcli/metadata.xml
+++ b/kde-misc/kwalletcli/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
 		<email>admin@pinkbyte.ru</email>
 		<name>Sergey Popov</name>
 	</maintainer>


### PR DESCRIPTION
Recently kdelibs ebuild was moved to kde-frameworks category as opposed to the previous kde-base category.

Fixing kwallet-cli ebuild so it passes the @world dependency tree resolution.